### PR TITLE
Fix registration of file reader service

### DIFF
--- a/packages/SVG-Morphic.package/SVGMorph.class/class/fileReaderServicesForFile.suffix..st
+++ b/packages/SVG-Morphic.package/SVGMorph.class/class/fileReaderServicesForFile.suffix..st
@@ -1,4 +1,4 @@
-as yet unclassified
+fileIn/Out
 fileReaderServicesForFile: fullName suffix: suffix
 	"registers the given class as providing services for reading files with Fileservices"
 

--- a/packages/SVG-Morphic.package/SVGMorph.class/class/initialize.st
+++ b/packages/SVG-Morphic.package/SVGMorph.class/class/initialize.st
@@ -1,0 +1,4 @@
+class initialization
+initialize
+
+	FileServices registerFileReader: self.

--- a/packages/SVG-Morphic.package/SVGMorph.class/class/initialize.st
+++ b/packages/SVG-Morphic.package/SVGMorph.class/class/initialize.st
@@ -1,4 +1,4 @@
 class initialization
 initialize
 
-	FileServices registerFileReader: self.
+	FileServices registerFileReader: self

--- a/packages/SVG-Morphic.package/SVGMorph.class/class/services.st
+++ b/packages/SVG-Morphic.package/SVGMorph.class/class/services.st
@@ -1,4 +1,4 @@
-as yet unclassified
+fileIn/Out
 services
 
 	^ {SimpleServiceEntry

--- a/packages/SVG-Morphic.package/SVGMorph.class/class/unload.st
+++ b/packages/SVG-Morphic.package/SVGMorph.class/class/unload.st
@@ -1,0 +1,4 @@
+initialize-release
+unload
+
+	FileServices unregisterFileReader: self.

--- a/packages/SVG-Morphic.package/SVGMorph.class/class/unload.st
+++ b/packages/SVG-Morphic.package/SVGMorph.class/class/unload.st
@@ -1,4 +1,4 @@
 initialize-release
 unload
 
-	FileServices unregisterFileReader: self.
+	FileServices unregisterFileReader: self

--- a/packages/SVG-Morphic.package/SVGMorph.class/methodProperties.json
+++ b/packages/SVG-Morphic.package/SVGMorph.class/methodProperties.json
@@ -6,7 +6,9 @@
 		"fromFile:" : "lra 6/12/2022 18:55",
 		"fromFileStream:" : "lha 5/22/2022 15:49",
 		"fromString:" : "lra 6/12/2022 16:30",
-		"services" : "lra 6/12/2022 16:30" },
+		"initialize" : "ct 7/16/2022 20:12",
+		"services" : "lra 6/12/2022 16:30",
+		"unload" : "ct 7/16/2022 20:19" },
 	"instance" : {
 		"accept:" : "aes 5/14/2022 17:41",
 		"composedStyle" : "lra 6/12/2022 18:38",


### PR DESCRIPTION
Adds missing #initialize and #unload methods to register SVGMorph as a service for opening svg files as a morph. Fixes #74.